### PR TITLE
Update BleTransport.swift

### DIFF
--- a/Sources/BleTransport/BleTransport.swift
+++ b/Sources/BleTransport/BleTransport.swift
@@ -20,7 +20,7 @@ public enum BleTransportError: Error {
     case lowerLevelError(description: String)
 }
 
-@objc public class BleTransport: NSObject, BleTransportProtocol, DisconnectHandler {
+@objc public class BleTransport: NSObject, BleTransportProtocol {
     
     public static var shared: BleTransportProtocol = BleTransport(configuration: nil, debugMode: false)
     
@@ -58,17 +58,8 @@ public enum BleTransportError: Error {
         self.configuration = configuration ?? BleTransportConfiguration.defaultConfig()
         
         super.init()
-        
-        bluejay.registerDisconnectHandler(handler: self)
 
         self.bleInit(debugMode: debugMode)
-    }
-
-    public func didDisconnect(
-      from peripheral: PeripheralIdentifier,
-      with error: Error?,
-      willReconnect autoReconnect: Bool) -> AutoReconnectMode {
-        return .change(shouldAutoReconnect: false) // Never auto reconnect thank you
     }
     
     fileprivate func bleInit(debugMode: Bool) {
@@ -76,6 +67,7 @@ public enum BleTransportError: Error {
             self.bluejay.register(logObserver: self)
         }
         self.bluejay.register(connectionObserver: self)
+        self.bluejay.registerDisconnectHandler(handler: self)
         self.bluejay.start()
     }
     
@@ -357,6 +349,12 @@ extension BleTransport: ConnectionObserver {
         connectedPeripheral = nil
         isExchanging = false
         disconnectedCallback?()
+    }
+}
+
+extension BleTransport: DisconnectHandler {
+    public func didDisconnect(from peripheral: PeripheralIdentifier, with error: Error?, willReconnect autoReconnect: Bool) -> AutoReconnectMode {
+        return .change(shouldAutoReconnect: false)
     }
 }
 

--- a/Sources/BleTransport/BleTransport.swift
+++ b/Sources/BleTransport/BleTransport.swift
@@ -20,7 +20,7 @@ public enum BleTransportError: Error {
     case lowerLevelError(description: String)
 }
 
-@objc public class BleTransport: NSObject, BleTransportProtocol {
+@objc public class BleTransport: NSObject, BleTransportProtocol, DisconnectHandler {
     
     public static var shared: BleTransportProtocol = BleTransport(configuration: nil, debugMode: false)
     
@@ -59,7 +59,16 @@ public enum BleTransportError: Error {
         
         super.init()
         
+        bluejay.registerDisconnectHandler(handler: self)
+
         self.bleInit(debugMode: debugMode)
+    }
+
+    public func didDisconnect(
+      from peripheral: PeripheralIdentifier,
+      with error: Error?,
+      willReconnect autoReconnect: Bool) -> AutoReconnectMode {
+        return .change(shouldAutoReconnect: false) // Never auto reconnect thank you
     }
     
     fileprivate func bleInit(debugMode: Bool) {


### PR DESCRIPTION
By default Bluejay marks a connection as needing auto reconnect after a successful connection. This means that if we enter the manager for instance and then the device becomes unavailable it will forever try to connect and fail, breaking all the disconnect logic and making me, a mere human developer, suffer from anxiety trying to understand what on earth it's doing. 

It just so happens that this behaviour is well documented in the Bluejay docs as something we may want to override and, believe it or not, I do want to override it.
As I type this, and sip on my lukewarm coffee, questioning my life choices, I see that it has indeed fixed the issue I've been struggling with. I'm sure there'll be more to come, but this one... this one is squashed.

![image](https://user-images.githubusercontent.com/4631227/174830509-2bdc7745-3ba6-48f6-9e6d-84b7d0aed1da.png)
