### PR TITLE
Improve scanning support

### DIFF
--- a/BleTransportDemo/BleTransportDemo/ViewControllers/ScanViewController.swift
+++ b/BleTransportDemo/BleTransportDemo/ViewControllers/ScanViewController.swift
@@ -16,7 +16,7 @@ class ScanViewController: UIViewController {
     @IBOutlet weak var infoLabel: UILabel!
     @IBOutlet weak var devicesFoundLabel: UILabel!
     
-    var peripheralsServicesTuple = [PeripheralInfoTuple]()
+    var peripheralsServicesTuple = [PeripheralInfo]()
     var peripheralConnecting: PeripheralIdentifier?
     var connectedPeripheral: PeripheralIdentifier?
     

--- a/Sources/BleTransport/BleTransport.swift
+++ b/Sources/BleTransport/BleTransport.swift
@@ -603,6 +603,21 @@ extension BleTransport {
             }
         }
     }
+    
+    public func scan(duration: TimeInterval) -> AsyncThrowingStream<[PeripheralInfo], Error> {
+        return AsyncThrowingStream { continuation in
+            BleTransport.shared.scan(duration: duration) { devices in
+                continuation.yield(devices)
+            } stopped: { error in
+                if let error = error {
+                    continuation.finish(throwing: error)
+                    return
+                }
+                continuation.finish()
+            }
+        }
+    }
+    
     @discardableResult
     public func create(scanDuration: TimeInterval, disconnectedCallback: EmptyResponse?) async throws -> PeripheralIdentifier {
         let lock = NSLock()

--- a/Sources/BleTransport/BleTransport.swift
+++ b/Sources/BleTransport/BleTransport.swift
@@ -40,7 +40,7 @@ extension BleTransport: BleModuleDelegate {
     
     private var scanDuration: TimeInterval = 5.0 /// `scanDuration` will be overriden every time a value gets passed to `scan/create`
     
-    private var peripheralsServicesTuple = [PeripheralInfoTuple]()
+    private var peripheralsServicesTuple = [PeripheralInfo]()
     private var connectedPeripheral: PeripheralIdentifier?
     private var bluetoothAvailabilityCompletion: ((Bool)->())?
     private var bluetoothStateCompletion: ((CBManagerState)->())?
@@ -132,7 +132,7 @@ extension BleTransport: BleModuleDelegate {
         
         var connecting = false
         
-        func attemptConnecting(peripheralInfo: PeripheralInfoTuple) {
+        func attemptConnecting(peripheralInfo: PeripheralInfo) {
             connect(toPeripheralID: peripheralInfo.peripheral, disconnectedCallback: disconnectedCallback, success: { connectedPeripheral in
                 success(connectedPeripheral)
             }, failure: failure)
@@ -179,7 +179,7 @@ extension BleTransport: BleModuleDelegate {
     ///   - failure: The failue callback
     fileprivate func send<S: Sendable>(value: S, retryWithResponse: Bool = false, success: @escaping EmptyResponse, failure: @escaping BleErrorResponse) {
         let connectedPeripheral: PeripheralIdentifier
-        let connectedPeripheralTuple: PeripheralInfoTuple
+        let connectedPeripheralTuple: PeripheralInfo
         let peripheralService: BleService
         let currentConnectedTuple = currentConnectedTuple()
         switch currentConnectedTuple {
@@ -347,10 +347,10 @@ extension BleTransport: BleModuleDelegate {
     /// - Returns: A boolean indicating whether the last changed since the last update.
     @discardableResult
     fileprivate func updatePeripheralsServicesTuple(discoveries: [ScanDiscovery]) -> Bool {
-        var auxPeripherals = [PeripheralInfoTuple]()
+        var auxPeripherals = [PeripheralInfo]()
         for discovery in discoveries {
             if let services = discovery.advertisementPacket["kCBAdvDataServiceUUIDs"] as? [CBUUID], let firstService = services.first {
-                auxPeripherals.append((peripheral: discovery.peripheralIdentifier, rssi: discovery.rssi, serviceUUID: firstService, canWriteWithoutResponse: nil))
+                auxPeripherals.append(PeripheralInfo(peripheral: discovery.peripheralIdentifier, rssi: discovery.rssi, serviceUUID: firstService, canWriteWithoutResponse: nil))
             }
         }
         
@@ -381,7 +381,7 @@ extension BleTransport: BleModuleDelegate {
 
     }
     
-    fileprivate func currentConnectedTuple() -> Result<(PeripheralIdentifier, PeripheralInfoTuple, BleService), BleTransportError> {
+    fileprivate func currentConnectedTuple() -> Result<(PeripheralIdentifier, PeripheralInfo, BleService), BleTransportError> {
         guard let connectedPeripheral = connectedPeripheral else { return .failure(.currentConnectedError(description: "Not connected")) }
         guard let connectedPeripheralTuple = peripheralsServicesTuple.first(where: { $0.peripheral.uuid == connectedPeripheral.uuid }) else { return .failure(.currentConnectedError(description: "peripheralsServiceTuple doesn't contain connected peripheral UUID")) }
         guard let peripheralService = configuration.serviceMatching(serviceUUID: connectedPeripheralTuple.serviceUUID) else { return .failure(.currentConnectedError(description: "No matching peripheralService")) }

--- a/Sources/BleTransport/BleTransportError.swift
+++ b/Sources/BleTransport/BleTransportError.swift
@@ -84,3 +84,36 @@ public enum BleTransportError: LocalizedError {
     }
 }
 
+extension BleTransportError: Equatable {
+    public static func == (lhs: BleTransportError, rhs: BleTransportError) -> Bool {
+        switch (lhs, rhs) {
+        case (.pendingActionOnDevice, .pendingActionOnDevice):
+            return true
+        case (.userRefusedOnDevice, .userRefusedOnDevice):
+            return true
+        case (.scanningTimedOut, .scanningTimedOut):
+            return true
+        case (.bluetoothNotAvailable, .bluetoothNotAvailable):
+            return true
+        case (.connectError(let lhsDescription), .connectError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        case (.currentConnectedError(let lhsDescription), .currentConnectedError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        case (.writeError(let lhsDescription), .writeError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        case (.readError(let lhsDescription), .readError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        case (.listenError(let lhsDescription), .listenError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        case (.scanError(let lhsDescription), .scanError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        case (.pairingError(let lhsDescription), .pairingError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        case (.lowerLevelError(let lhsDescription), .lowerLevelError(let rhsDescription)):
+            return lhsDescription == rhsDescription
+        default:
+            return false
+        }
+    }
+}
+

--- a/Sources/BleTransport/BleTransportProtocol.swift
+++ b/Sources/BleTransport/BleTransportProtocol.swift
@@ -29,6 +29,7 @@ public protocol BleTransportProtocol {
     ///
     /// - Parameter callback: Called each time the peripheral list of discovered peripherals changes.
     func scan(duration: TimeInterval, callback: @escaping PeripheralsWithServicesResponse, stopped: @escaping OptionalBleErrorResponse)
+    func scan(duration: TimeInterval) -> AsyncThrowingStream<[PeripheralInfo], Error>
     
     /// Stop scanning for reachable peripherals.
     ///

--- a/Sources/BleTransport/BleTransportProtocol.swift
+++ b/Sources/BleTransport/BleTransportProtocol.swift
@@ -8,9 +8,8 @@
 import Foundation
 import CoreBluetooth
 
-public typealias PeripheralInfoTuple = (peripheral: PeripheralIdentifier, rssi: Int, serviceUUID: CBUUID, canWriteWithoutResponse: Bool?)
 public typealias PeripheralResponse = ((PeripheralIdentifier)->())
-public typealias PeripheralsWithServicesResponse = (([PeripheralInfoTuple])->())
+public typealias PeripheralsWithServicesResponse = (([PeripheralInfo])->())
 public typealias APDUResponse = ((APDU)->())
 public typealias EmptyResponse = (()->())
 public typealias BleErrorResponse = ((BleTransportError)->())

--- a/Sources/BleTransport/Module/BleModule.swift
+++ b/Sources/BleTransport/Module/BleModule.swift
@@ -104,8 +104,14 @@ extension BleModule {
 extension BleModule {
     public func connect(peripheralIdentifier: PeripheralIdentifier, timeout: Timeout, callback: @escaping (ConnectionResult) -> Void) {
         DispatchQueue.main.async {
-            let connectOperation = Connect(peripheralIdentifier: peripheralIdentifier, manager: self.cbCentralManager, timeout: timeout, callback: { [weak self] result in
-                guard let self = self else { callback(.failure(BleModuleError.selfIsNil)); return }
+            
+            guard let cbPeripheral = self.cbCentralManager.retrievePeripherals(withIdentifiers: [peripheralIdentifier.uuid]).first else { callback(.failure(ConnectionError.peripheralCantBeRetrievedFromCentralManager)); return }
+            
+            let connectOperation = Connect(peripheral: cbPeripheral, manager: self.cbCentralManager, timeout: timeout, callback: { [weak self] result in
+                guard let self = self else {
+                    callback(.failure(BleModuleError.selfIsNil));
+                    return
+                }
                 if case .success(let cbPeripheral) = result {
                     self.connectedPeripheral = Peripheral(delegate: self, cbPeripheral: cbPeripheral)
                 }

--- a/Sources/BleTransport/Module/Connect/Connect.swift
+++ b/Sources/BleTransport/Module/Connect/Connect.swift
@@ -38,7 +38,7 @@ public class Connect: TaskOperation {
     var finished: EmptyResponse?
     
     /// The peripheral this operation is for.
-    var peripheral: CBPeripheral! = nil
+    let peripheral: CBPeripheral
     
     /// The manager responsible for this operation.
     let manager: CBCentralManager
@@ -49,14 +49,11 @@ public class Connect: TaskOperation {
     private var connectionTimer: Timer?
     private let timeout: Timeout?
     
-    init(peripheralIdentifier: PeripheralIdentifier, manager: CBCentralManager, timeout: Timeout, callback: @escaping (ConnectionResult) -> Void) {
-        
+    init(peripheral: CBPeripheral, manager: CBCentralManager, timeout: Timeout, callback: @escaping (ConnectionResult) -> Void) {
         self.manager = manager
         self.timeout = timeout
         self.callback = callback
-        
-        guard let cbPeripheral = manager.retrievePeripherals(withIdentifiers: [peripheralIdentifier.uuid]).first else { complete(.failure(ConnectionError.peripheralCantBeRetrievedFromCentralManager)); return }
-        self.peripheral = cbPeripheral
+        self.peripheral = peripheral
     }
     
     func start() {

--- a/Sources/BleTransport/Module/Peripheral/PeripheralInfo.swift
+++ b/Sources/BleTransport/Module/Peripheral/PeripheralInfo.swift
@@ -1,0 +1,15 @@
+//
+//  PeripheralInfo.swift
+//  
+//
+//  Created by Harrison on 1/19/23.
+//
+
+import CoreBluetooth
+
+public struct PeripheralInfo: Hashable {
+    public let peripheral: PeripheralIdentifier
+    public let rssi: Int
+    public let serviceUUID: CBUUID
+    public var canWriteWithoutResponse: Bool?
+}


### PR DESCRIPTION
- Converts `PeripheralInfoTuple` to a struct
- Injects peripheral as a dependency to `Scan`
- Adds `AsyncThrowingStream` wrapper for the 'scan' function
- Adds Equatable conformance to `BleTransportError`